### PR TITLE
Provide the X-Request-Tracker header as a response header.

### DIFF
--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerConfiguration.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerConfiguration.java
@@ -17,7 +17,7 @@ public class RequestTrackerConfiguration {
 		return this.addResponseHeader;
 	}
 
-	public void setAddResponseHeader( Boolean val ) {
+	public void setAddResponseHeader(Boolean val) {
 		this.addResponseHeader = val;
 	}
 

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerConfiguration.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerConfiguration.java
@@ -3,27 +3,36 @@ package com.serviceenabled.dropwizardrequesttracker;
 public class RequestTrackerConfiguration {
 
 	public RequestTrackerConfiguration() {}
-	
+
 	public RequestTrackerConfiguration(String headerName, String mdcKey) {
 		setHeaderName(headerName);
 		setMdcKey(mdcKey);
 	}
-	
+
 	private String headerName = "X-Request-Tracker";
 	private String mdcKey = "Request-Tracker";
+	private Boolean addResponseHeader = false;
+
+	public Boolean getAddResponseHeader() {
+		return this.addResponseHeader;
+	}
+
+	public void setAddResponseHeader( Boolean val ) {
+		this.addResponseHeader = val;
+	}
 
 	public String getHeaderName() {
 		return headerName;
 	}
-	
+
 	public void setHeaderName(String headerName) {
 		this.headerName = headerName;
 	}
-	
+
 	public String getMdcKey() {
 		return mdcKey;
 	}
-	
+
 	public void setMdcKey(String mdcKey) {
 		this.mdcKey = mdcKey;
 	}

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
@@ -9,6 +9,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.MDC;
 
@@ -34,9 +35,17 @@ public class RequestTrackerServletFilter implements Filter {
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+		HttpServletRequest httpServletRequest  = (HttpServletRequest) request;
+		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
 		Optional<String> requestId = Optional.fromNullable(httpServletRequest.getHeader(configuration.getHeaderName()));
-		MDC.put(configuration.getMdcKey(), requestId.or(idSupplier));
+		String resolvedId = requestId.or(idSupplier);
+
+		MDC.put(configuration.getMdcKey(), resolvedId);
+
+		if( configuration.getAddResponseHeader() ) {
+			httpServletResponse.addHeader( configuration.getHeaderName(), resolvedId );
+		}
+
 		chain.doFilter(request, response);
 	}
 

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
@@ -43,7 +43,7 @@ public class RequestTrackerServletFilter implements Filter {
 		MDC.put(configuration.getMdcKey(), resolvedId);
 
 		if(configuration.getAddResponseHeader()) {
-			httpServletResponse.addHeader( configuration.getHeaderName(), resolvedId );
+			httpServletResponse.addHeader(configuration.getHeaderName(), resolvedId);
 		}
 
 		chain.doFilter(request, response);

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
@@ -35,14 +35,14 @@ public class RequestTrackerServletFilter implements Filter {
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-		HttpServletRequest httpServletRequest  = (HttpServletRequest) request;
+		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
 		Optional<String> requestId = Optional.fromNullable(httpServletRequest.getHeader(configuration.getHeaderName()));
 		String resolvedId = requestId.or(idSupplier);
 
 		MDC.put(configuration.getMdcKey(), resolvedId);
 
-		if( configuration.getAddResponseHeader() ) {
+		if(configuration.getAddResponseHeader()) {
 			httpServletResponse.addHeader( configuration.getHeaderName(), resolvedId );
 		}
 

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilterTest.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilterTest.java
@@ -2,6 +2,7 @@ package com.serviceenabled.dropwizardrequesttracker;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.isNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,12 +11,14 @@ import java.util.UUID;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.MDC;
 
@@ -25,7 +28,7 @@ public class RequestTrackerServletFilterTest {
 	private RequestTrackerConfiguration configuration;
 
 	@Mock private HttpServletRequest request;
-	@Mock private ServletResponse response;
+	@Mock private HttpServletResponse response;
 	@Mock private FilterChain chain;
 
 	@Before
@@ -72,4 +75,14 @@ public class RequestTrackerServletFilterTest {
 		assertThat(idInLog, equalTo(headerId));
 	}
 
+	@Test
+	public void addsResponseHeaderWhenConfigured() throws Exception {
+		this.configuration.setAddResponseHeader(true);
+
+		//Re-injecting the configuration to ensure the updated configuration is applied.
+		requestTrackerServletFilter = new RequestTrackerServletFilter(this.configuration);
+		requestTrackerServletFilter.doFilter(request, response, chain);
+
+		verify(response).addHeader( configuration.getHeaderName(), MDC.get(configuration.getMdcKey()));
+	}
 }


### PR DESCRIPTION
The Request-Tracker ID that's made available in the logging context is
very useful for debugging requests for a troubled client.  By adding the
same request id as a response header, we can easily ask the same client
for a request id that failed to narrow down our search.

To ensure functionality doesn't change for existing clients, the request
header must be explicitly enabled before it will be added.  The same
header name that's used in the request object will be used.