### PR TITLE
Upgrading to use dropwizard 0.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
 			<groupId>io.dropwizard</groupId>
 			<artifactId>dropwizard-client</artifactId>
 			<version>${dropwizard.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.dropwizard</groupId>
@@ -120,7 +126,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -138,7 +144,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.9.5</version>
+			<version>1.10.19</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,6 @@
 	</build>
 
 	<properties>
-		<dropwizard.version>0.7.1</dropwizard.version>
+		<dropwizard.version>0.9.1</dropwizard.version>
 	</properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.serviceenabled</groupId>
 	<artifactId>dropwizard-request-tracker</artifactId>
-	<version>0.2.1-SNAPSHOT</version>
+	<version>2.0.0</version>
 	<name>Dropwizard Request Tracker</name>
 	<url>https://github.com/service-enabled/dropwizard-request-tracker</url>
 	<description>

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilter.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilter.java
@@ -13,10 +13,6 @@ public class RequestTrackerClientFilter implements ClientRequestFilter {
     private final RequestTrackerConfiguration configuration;
     private final Supplier<String> idSupplier;
 
-    public RequestTrackerClientFilter() {
-        this(null, new UuidSupplier());
-    }
-
     public RequestTrackerClientFilter(RequestTrackerConfiguration configuration) {
         this(configuration, new UuidSupplier());
     }

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilter.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilter.java
@@ -13,6 +13,10 @@ public class RequestTrackerClientFilter implements ClientRequestFilter {
     private final RequestTrackerConfiguration configuration;
     private final Supplier<String> idSupplier;
 
+    public RequestTrackerClientFilter() {
+        this(null, new UuidSupplier());
+    }
+
     public RequestTrackerClientFilter(RequestTrackerConfiguration configuration) {
         this(configuration, new UuidSupplier());
     }

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilterTest.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilterTest.java
@@ -1,15 +1,5 @@
 package com.serviceenabled.dropwizardrequesttracker;
 
-import static org.hamcrest.CoreMatchers.any;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.UUID;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +9,13 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.MDC;
 
-import com.sun.jersey.api.client.ClientRequest;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.UUID;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -27,7 +23,7 @@ public class RequestTrackerClientFilterTest {
     private RequestTrackerClientFilter requestTrackerClientFilter;
     private RequestTrackerConfiguration configuration;
 
-    @Mock private ClientRequest clientRequest;
+    @Mock private ClientRequestContext clientRequest;
     @Mock private MultivaluedMap<String,Object> headersMap;
 
     @Before
@@ -43,13 +39,8 @@ public class RequestTrackerClientFilterTest {
     }
 
     @Test
-    public void returnsClientRequest() {
-        assertThat(requestTrackerClientFilter.doWork(clientRequest), any(ClientRequest.class));
-    }
-
-    @Test
     public void setsTheRequestTrackerHeader() {
-        requestTrackerClientFilter.doWork(clientRequest);
+        requestTrackerClientFilter.filter(clientRequest);
 
         verify(headersMap).add(eq(this.configuration.getHeaderName()), Mockito.any(UUID.class));
     }
@@ -58,7 +49,7 @@ public class RequestTrackerClientFilterTest {
     public void usesExistingMDCValueWhenPresent() {
         String logId = UUID.randomUUID().toString();
         MDC.put(this.configuration.getMdcKey(), logId);
-        requestTrackerClientFilter.doWork(clientRequest);
+        requestTrackerClientFilter.filter(clientRequest);
 
         verify(headersMap).add(eq(this.configuration.getHeaderName()), eq(logId));
     }

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/it/BundleApplicationIT.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/it/BundleApplicationIT.java
@@ -10,14 +10,16 @@ import java.util.UUID;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
 import org.junit.rules.RuleChain;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.Entity;
 
 
 public class BundleApplicationIT {
-	private static final DropwizardAppRule<BundleConfiguration> DROPWIZARD_APP_RULE = new DropwizardAppRule<BundleConfiguration>(BundleApplication.class, null);
+	private static final DropwizardAppRule<BundleConfiguration> DROPWIZARD_APP_RULE = new DropwizardAppRule<BundleConfiguration>(BundleApplication.class);
 	private static final IntegrationTestSetupRule INTEGRATION_TEST_SETUP_RULE = new IntegrationTestSetupRule(DROPWIZARD_APP_RULE);
 
 	@ClassRule
@@ -35,19 +37,21 @@ public class BundleApplicationIT {
 	@Test
 	public void addsTrackerToOutgoingRequest() throws Exception {
 		Client client = INTEGRATION_TEST_SETUP_RULE.getClient();
-		client.resource(INTEGRATION_TEST_SETUP_RULE.getInitialUri())
-				.post(ClientResponse.class);
+		client.target(INTEGRATION_TEST_SETUP_RULE.getInitialUri())
+				.request()
+				.post(Entity.json(null), ClientResponseContext.class);
 
 		assertThat(INTEGRATION_TEST_SETUP_RULE.getMockTestResource().getRequestTrackerId(), notNullValue());
 	}
 
 	@Test
 	public void keepsTheId() throws Exception {
-		Client client = new Client();
+		Client client = ClientBuilder.newClient();
 		UUID id = UUID.randomUUID();
-		client.resource(INTEGRATION_TEST_SETUP_RULE.getInitialUri())
+		client.target(INTEGRATION_TEST_SETUP_RULE.getInitialUri())
+				.request()
 				.header(INTEGRATION_TEST_SETUP_RULE.getConfiguration().getHeaderName(), id)
-				.post(ClientResponse.class);
+				.post(Entity.json(null),ClientResponseContext.class);
 
 		assertThat(INTEGRATION_TEST_SETUP_RULE.getMockTestResource().getRequestTrackerId(), equalTo(id.toString()));
 	}

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/it/ClientTestResource.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/it/ClientTestResource.java
@@ -4,8 +4,9 @@ import java.net.URI;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
 
-import com.sun.jersey.api.client.Client;
 
 /**
  * Created by rmuhic on 11/11/2014.
@@ -15,13 +16,24 @@ public class ClientTestResource {
     private Client client;
     private URI uri;
 
+    public ClientTestResource(){
+    }
+
     public ClientTestResource(URI uri, Client client){
         this.uri = uri;
         this.client = client;
     }
 
+    public void setClient(Client client) {
+        this.client = client;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
     @POST
     public void test(){
-        client.resource(uri).post();
+        client.target(uri).request().post(Entity.json(null));
     }
 }

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/it/CustomIdSupplierBundleApplicationIT.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/it/CustomIdSupplierBundleApplicationIT.java
@@ -1,18 +1,21 @@
 package com.serviceenabled.dropwizardrequesttracker.it;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.Entity;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 
 public class CustomIdSupplierBundleApplicationIT {
-	private static final DropwizardAppRule<BundleConfiguration> DROPWIZARD_APP_RULE = new DropwizardAppRule<BundleConfiguration>(CustomIdSupplierBundleApplication.class, null);
+	private static final DropwizardAppRule<BundleConfiguration> DROPWIZARD_APP_RULE = new DropwizardAppRule<BundleConfiguration>(CustomIdSupplierBundleApplication.class);
 	private static final IntegrationTestSetupRule INTEGRATION_TEST_SETUP_RULE = new IntegrationTestSetupRule(DROPWIZARD_APP_RULE);
 
 	@ClassRule
@@ -22,8 +25,8 @@ public class CustomIdSupplierBundleApplicationIT {
 
 	@Test
 	public void suppliesCustomId() throws Exception {
-		Client client = new Client();
-		client.resource(INTEGRATION_TEST_SETUP_RULE.getInitialUri()).post(ClientResponse.class);
+		Client client = ClientBuilder.newClient();
+		client.target(INTEGRATION_TEST_SETUP_RULE.getInitialUri()).request().post(Entity.json(null), ClientResponseContext.class);
 
 		assertThat(INTEGRATION_TEST_SETUP_RULE.getMockTestResource().getRequestTrackerId(), equalTo("12345"));
 	}


### PR DESCRIPTION
Wanted to discuss handling the version number for the request-tracker artifact, but feel we should probably bump to at least 0.3 seeing as we're bringing in a new major version of dropwizard