### PR TITLE
Start of v3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,19 +144,26 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
+			<version>2.23.0</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.hamcrest</groupId>
-					<artifactId>hamcrest-core</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
 			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Java 9 javax removals -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -166,10 +173,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.8.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<release>8</release>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -244,6 +252,6 @@
 	</build>
 
 	<properties>
-		<dropwizard.version>0.9.1</dropwizard.version>
+		<dropwizard.version>1.3.7</dropwizard.version>
 	</properties>
 </project>

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerBundle.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerBundle.java
@@ -1,12 +1,10 @@
 package com.serviceenabled.dropwizardrequesttracker;
 
-import com.google.common.base.Supplier;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-
 import java.util.EnumSet;
-
+import java.util.function.Supplier;
 import javax.servlet.DispatcherType;
 
 public abstract class RequestTrackerBundle<T> implements ConfiguredBundle<T> {

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilter.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilter.java
@@ -1,12 +1,10 @@
 package com.serviceenabled.dropwizardrequesttracker;
 
-import org.slf4j.MDC;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
-
+import java.util.Optional;
+import java.util.function.Supplier;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
+import org.slf4j.MDC;
 
 
 public class RequestTrackerClientFilter implements ClientRequestFilter {
@@ -24,8 +22,9 @@ public class RequestTrackerClientFilter implements ClientRequestFilter {
 
     @Override
     public void filter(ClientRequestContext clientRequest) {
-        Optional<String> requestId = Optional.fromNullable(MDC.get(configuration.getMdcKey()));
+        Optional<String> requestId = Optional.ofNullable(MDC.get(configuration.getMdcKey()));
 
-        clientRequest.getHeaders().add(configuration.getHeaderName(), requestId.or(idSupplier));
+        clientRequest.getHeaders().add(configuration.getHeaderName(),
+            requestId.orElseGet(idSupplier));
     }
 }

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilter.java
@@ -1,7 +1,8 @@
 package com.serviceenabled.dropwizardrequesttracker;
 
 import java.io.IOException;
-
+import java.util.Optional;
+import java.util.function.Supplier;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -10,11 +11,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.MDC;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
 
 public class RequestTrackerServletFilter implements Filter {
 	// Use a supplier so we only generate id's when they're needed
@@ -37,8 +34,8 @@ public class RequestTrackerServletFilter implements Filter {
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 		HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 		HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-		Optional<String> requestId = Optional.fromNullable(httpServletRequest.getHeader(configuration.getHeaderName()));
-		String resolvedId = requestId.or(idSupplier);
+		Optional<String> requestId = Optional.ofNullable(httpServletRequest.getHeader(configuration.getHeaderName()));
+		String resolvedId = requestId.orElseGet(idSupplier);
 
 		MDC.put(configuration.getMdcKey(), resolvedId);
 

--- a/src/main/java/com/serviceenabled/dropwizardrequesttracker/UuidSupplier.java
+++ b/src/main/java/com/serviceenabled/dropwizardrequesttracker/UuidSupplier.java
@@ -1,6 +1,6 @@
 package com.serviceenabled.dropwizardrequesttracker;
 
-import com.google.common.base.Supplier;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilterTest.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerClientFilterTest.java
@@ -2,24 +2,25 @@ package com.serviceenabled.dropwizardrequesttracker;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.slf4j.MDC;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.UUID;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
-@RunWith(MockitoJUnitRunner.class)
 public class RequestTrackerClientFilterTest {
+    @Rule public MockitoRule rule = MockitoJUnit.rule();
+
     private RequestTrackerClientFilter requestTrackerClientFilter;
     private RequestTrackerConfiguration configuration;
 
@@ -34,7 +35,7 @@ public class RequestTrackerClientFilterTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         MDC.clear();
     }
 
@@ -42,7 +43,7 @@ public class RequestTrackerClientFilterTest {
     public void setsTheRequestTrackerHeader() {
         requestTrackerClientFilter.filter(clientRequest);
 
-        verify(headersMap).add(eq(this.configuration.getHeaderName()), Mockito.any(UUID.class));
+        verify(headersMap).add(eq(this.configuration.getHeaderName()), Mockito.any(String.class));
     }
 
     @Test

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilterTest.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/RequestTrackerServletFilterTest.java
@@ -2,28 +2,27 @@ package com.serviceenabled.dropwizardrequesttracker;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.isNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.slf4j.MDC;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RequestTrackerServletFilterTest {
+	@Rule public MockitoRule rule = MockitoJUnit.rule();
+
 	private RequestTrackerServletFilter requestTrackerServletFilter;
 	private RequestTrackerConfiguration configuration;
 
@@ -32,13 +31,13 @@ public class RequestTrackerServletFilterTest {
 	@Mock private FilterChain chain;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		this.configuration = new RequestTrackerConfiguration();
 		requestTrackerServletFilter = new RequestTrackerServletFilter(this.configuration);
 	}
 
 	@After
-	public void tearDown() throws Exception {
+	public void tearDown() {
 		MDC.clear();
 	}
 

--- a/src/test/java/com/serviceenabled/dropwizardrequesttracker/UuidSupplierTest.java
+++ b/src/test/java/com/serviceenabled/dropwizardrequesttracker/UuidSupplierTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.*;
 
 public class UuidSupplierTest {
 	@Test
-	public void suppliesAnId() throws Exception {
+	public void suppliesAnId() {
 		UuidSupplier uuidSupplier = new UuidSupplier();
 		String id = uuidSupplier.get();
 


### PR DESCRIPTION
See #33 

So far this does the following..

- Build with DW 1.3.7
- Target Java 8
- Use Java 8 Supplier and Optional
- Support builds with Java 9 and higher
- Upgrade mockito
- Remove deprecations
